### PR TITLE
Remove link to Beta form, update email address

### DIFF
--- a/templates/feedback.html
+++ b/templates/feedback.html
@@ -10,22 +10,12 @@
     {% endblocktrans %}
   </p>
 
-  <h2 class="govuk-heading-m">{% trans "Feedback Form" %}</h2>
-
-  <p class="govuk-body">
-    {% blocktrans %}
-      Complete the
-      <a href="https://forms.office.com/r/HNPq9d8WM1" target="_blank">feedback form (opens in a new tab)</a> - you can
-      do this anonymously if you do not need a response.
-    {% endblocktrans %}
-  </p>
-
   <h2 class="govuk-heading-m">{% trans "Email" %}</h2>
 
   <p class="govuk-body">
     {% blocktrans %}
       Email us at:
-      <a href="mailto:PHE.screeninghelpdesk@nhs.net?subject=Beta%20Feedback">PHE.screeninghelpdesk@nhs.net</a>.
+      <a href="mailto:screeninginformation@dhsc.gov.uk?subject=Beta%20Feedback">screeninginformation@dhsc.gov.uk</a>.
     {% endblocktrans %}
   </p>
 {% endblock %}


### PR DESCRIPTION
Removed link to Beta form (this was a Microsoft form associated to a now-deactivated account) and updated email address.