### PR TITLE
Restore admin function

### DIFF
--- a/nsc/contact/views.py
+++ b/nsc/contact/views.py
@@ -1,14 +1,14 @@
 from django.urls import reverse
 from django.views import generic
 
-from nsc.permissions import AdminRequiredMixin
+from nsc.permissions import ReviewManagerRequiredMixin
 from nsc.stakeholder.models import Stakeholder
 
 from .forms import ContactForm
 from .models import Contact
 
 
-class ContactAdd(AdminRequiredMixin, generic.CreateView):
+class ContactAdd(ReviewManagerRequiredMixin, generic.CreateView):
     model = Contact
     form_class = ContactForm
 
@@ -28,7 +28,7 @@ class ContactAdd(AdminRequiredMixin, generic.CreateView):
         return super().get_context_data(stakeholder=stakeholder, **kwargs)
 
 
-class ContactEdit(AdminRequiredMixin, generic.UpdateView):
+class ContactEdit(ReviewManagerRequiredMixin, generic.UpdateView):
     model = Contact
     form_class = ContactForm
 
@@ -40,7 +40,7 @@ class ContactEdit(AdminRequiredMixin, generic.UpdateView):
         return reverse("stakeholder:detail", kwargs={"pk": self.object.stakeholder.pk})
 
 
-class ContactDelete(AdminRequiredMixin, generic.DeleteView):
+class ContactDelete(ReviewManagerRequiredMixin, generic.DeleteView):
     model = Contact
 
     def get_success_url(self):

--- a/nsc/document/views.py
+++ b/nsc/document/views.py
@@ -6,7 +6,7 @@ from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 from django.views import generic
 
-from nsc.permissions import AdminRequiredMixin
+from nsc.permissions import ReviewManagerRequiredMixin
 from nsc.review.models import Review
 
 from ..utils.urls import clean_url
@@ -14,7 +14,7 @@ from .forms import ExternalReviewForm, ReviewDocumentsForm, SubmissionForm
 from .models import Document
 
 
-class AddExternalReviewView(AdminRequiredMixin, generic.UpdateView):
+class AddExternalReviewView(ReviewManagerRequiredMixin, generic.UpdateView):
     template_name = "document/add_external_review.html"
     form_class = ExternalReviewForm
     model = Review
@@ -30,7 +30,7 @@ class AddExternalReviewView(AdminRequiredMixin, generic.UpdateView):
         )
 
 
-class AddSubmissionFormView(AdminRequiredMixin, generic.CreateView):
+class AddSubmissionFormView(ReviewManagerRequiredMixin, generic.CreateView):
     template_name = "document/add_submission_form.html"
     form_class = SubmissionForm
 
@@ -79,7 +79,7 @@ class AddSubmissionFormView(AdminRequiredMixin, generic.CreateView):
         )
 
 
-class AddReviewDocumentsView(AdminRequiredMixin, generic.UpdateView):
+class AddReviewDocumentsView(ReviewManagerRequiredMixin, generic.UpdateView):
     template_name = "document/add_review_documents.html"
     form_class = ReviewDocumentsForm
     model = Review
@@ -114,7 +114,7 @@ class DownloadView(generic.DetailView):
         )
 
 
-class DeleteView(AdminRequiredMixin, generic.DeleteView):
+class DeleteView(ReviewManagerRequiredMixin, generic.DeleteView):
     model = Document
 
     def get_success_url(self):

--- a/nsc/permissions.py
+++ b/nsc/permissions.py
@@ -2,7 +2,7 @@ from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.utils.cache import add_never_cache_headers
 
 
-class AdminRequiredMixin(PermissionRequiredMixin):
+class ReviewManagerRequiredMixin(PermissionRequiredMixin):
     permission_required = "review.evidence_review_manager"
 
     def dispatch(self, *args, **kwargs):

--- a/nsc/policy/views.py
+++ b/nsc/policy/views.py
@@ -5,7 +5,7 @@ from django.views.generic import CreateView, DetailView, UpdateView
 
 from django_filters.views import FilterView
 
-from nsc.permissions import AdminRequiredMixin
+from nsc.permissions import ReviewManagerRequiredMixin
 
 from .filters import SearchFilter
 from .forms import (
@@ -43,7 +43,7 @@ class PublishPreviewMixin:
             )
 
 
-class PolicyList(AdminRequiredMixin, FilterView):
+class PolicyList(ReviewManagerRequiredMixin, FilterView):
     model = Policy
     paginate_by = 20
     template_name = "policy/admin/policy_list.html"
@@ -59,7 +59,7 @@ class PolicyList(AdminRequiredMixin, FilterView):
         return super().get_context_data(form=form)
 
 
-class PolicyDetail(AdminRequiredMixin, DetailView):
+class PolicyDetail(ReviewManagerRequiredMixin, DetailView):
     model = Policy
     lookup_field = "slug"
     context_object_name = "policy"
@@ -71,7 +71,7 @@ class PolicyDetail(AdminRequiredMixin, DetailView):
         )
 
 
-class PolicyAddMixin(AdminRequiredMixin):
+class PolicyAddMixin(ReviewManagerRequiredMixin):
     model = Policy
     section = None
     next_section = None
@@ -128,7 +128,7 @@ class PolicyAddRecommendation(SuccessMessageMixin, PolicyAddMixin, UpdateView):
         return reverse("review:add") + f"?policy={self.object.slug}"
 
 
-class PolicyEdit(AdminRequiredMixin, PublishPreviewMixin, UpdateView):
+class PolicyEdit(ReviewManagerRequiredMixin, PublishPreviewMixin, UpdateView):
     model = Policy
     lookup_field = "slug"
     form_class = PolicyEditForm
@@ -137,21 +137,21 @@ class PolicyEdit(AdminRequiredMixin, PublishPreviewMixin, UpdateView):
     success_message = "Published changes to conditions page."
 
 
-class ArchiveDetail(AdminRequiredMixin, DetailView):
+class ArchiveDetail(ReviewManagerRequiredMixin, DetailView):
     model = Policy
     lookup_field = "slug"
     context_object_name = "policy"
     template_name = "policy/admin/archive/detail.html"
 
 
-class ArchiveDocumentDetail(AdminRequiredMixin, DetailView):
+class ArchiveDocumentDetail(ReviewManagerRequiredMixin, DetailView):
     model = Policy
     lookup_field = "slug"
     context_object_name = "policy"
     template_name = "policy/admin/archive/document.html"
 
 
-class ArchiveDocumentUploadView(AdminRequiredMixin, UpdateView):
+class ArchiveDocumentUploadView(ReviewManagerRequiredMixin, UpdateView):
     form_class = PolicyDocumentForm
     model = Policy
     lookup_field = "slug"
@@ -162,7 +162,7 @@ class ArchiveDocumentUploadView(AdminRequiredMixin, UpdateView):
         return reverse("policy:archive:upload", kwargs={"slug": self.kwargs["slug"]})
 
 
-class ArchiveUpdate(AdminRequiredMixin, PublishPreviewMixin, UpdateView):
+class ArchiveUpdate(ReviewManagerRequiredMixin, PublishPreviewMixin, UpdateView):
     form_class = ArchiveForm
     model = Policy
     lookup_field = "slug"
@@ -173,7 +173,7 @@ class ArchiveUpdate(AdminRequiredMixin, PublishPreviewMixin, UpdateView):
         return reverse("policy:archive:complete", kwargs={"slug": self.kwargs["slug"]})
 
 
-class ArchiveComplete(AdminRequiredMixin, PublishPreviewMixin, DetailView):
+class ArchiveComplete(ReviewManagerRequiredMixin, PublishPreviewMixin, DetailView):
     model = Policy
     lookup_field = "slug"
     context_object_name = "policy"

--- a/nsc/review/views.py
+++ b/nsc/review/views.py
@@ -7,7 +7,7 @@ from django.urls import reverse, reverse_lazy
 from django.utils.translation import ugettext_lazy as _
 from django.views import generic
 
-from nsc.permissions import AdminRequiredMixin
+from nsc.permissions import ReviewManagerRequiredMixin
 from nsc.policy.models import Policy
 from nsc.utils.datetime import get_today
 
@@ -25,7 +25,7 @@ from .forms import (
 from .models import Review
 
 
-class ReviewDashboardView(AdminRequiredMixin, generic.TemplateView):
+class ReviewDashboardView(ReviewManagerRequiredMixin, generic.TemplateView):
     template_name = "review/review_dashboard.html"
 
     def get_context_data(self, **kwargs):
@@ -37,7 +37,7 @@ class ReviewDashboardView(AdminRequiredMixin, generic.TemplateView):
         return super().get_context_data(reviews=reviews)
 
 
-class ReviewList(AdminRequiredMixin, generic.TemplateView):
+class ReviewList(ReviewManagerRequiredMixin, generic.TemplateView):
     template_name = "review/review_list.html"
 
     def get_context_data(self, **kwargs):
@@ -45,13 +45,13 @@ class ReviewList(AdminRequiredMixin, generic.TemplateView):
         return super().get_context_data(reviews=reviews)
 
 
-class ReviewDetail(AdminRequiredMixin, generic.DetailView):
+class ReviewDetail(ReviewManagerRequiredMixin, generic.DetailView):
     model = Review
     lookup_field = "slug"
     context_object_name = "review"
 
 
-class ReviewAdd(AdminRequiredMixin, generic.CreateView):
+class ReviewAdd(ReviewManagerRequiredMixin, generic.CreateView):
     model = Review
     form_class = ReviewForm
 
@@ -72,12 +72,12 @@ class ReviewAdd(AdminRequiredMixin, generic.CreateView):
         return initial
 
 
-class ReviewDelete(AdminRequiredMixin, generic.DeleteView):
+class ReviewDelete(ReviewManagerRequiredMixin, generic.DeleteView):
     model = Review
     success_url = reverse_lazy("dashboard")
 
 
-class ReviewDates(AdminRequiredMixin, generic.UpdateView):
+class ReviewDates(ReviewManagerRequiredMixin, generic.UpdateView):
     model = Review
     lookup_field = "slug"
     form_class = ReviewDatesForm
@@ -114,28 +114,28 @@ class ReviewDates(AdminRequiredMixin, generic.UpdateView):
         return reverse_lazy("review:open", kwargs={"slug": self.object.slug})
 
 
-class ReviewStakeholders(AdminRequiredMixin, generic.UpdateView):
+class ReviewStakeholders(ReviewManagerRequiredMixin, generic.UpdateView):
     model = Review
     lookup_field = "slug"
     form_class = ReviewStakeholdersForm
     template_name = "review/review_stakeholders.html"
 
 
-class ReviewSummary(AdminRequiredMixin, generic.UpdateView):
+class ReviewSummary(ReviewManagerRequiredMixin, generic.UpdateView):
     model = Review
     lookup_field = "slug"
     form_class = ReviewSummaryForm
     template_name = "review/review_summary.html"
 
 
-class ReviewHistory(AdminRequiredMixin, generic.UpdateView):
+class ReviewHistory(ReviewManagerRequiredMixin, generic.UpdateView):
     model = Review
     lookup_field = "slug"
     form_class = ReviewHistoryForm
     template_name = "review/review_history.html"
 
 
-class ReviewRecommendation(AdminRequiredMixin, generic.UpdateView):
+class ReviewRecommendation(ReviewManagerRequiredMixin, generic.UpdateView):
     model = Review
     lookup_field = "slug"
     form_class = ReviewRecommendationForm
@@ -145,7 +145,7 @@ class ReviewRecommendation(AdminRequiredMixin, generic.UpdateView):
         return reverse("review:publish", kwargs={"slug": self.object.slug})
 
 
-class ReviewPublish(AdminRequiredMixin, generic.UpdateView):
+class ReviewPublish(ReviewManagerRequiredMixin, generic.UpdateView):
     model = Review
     lookup_field = "slug"
     form_class = ReviewPublishForm
@@ -160,7 +160,7 @@ class ReviewPublish(AdminRequiredMixin, generic.UpdateView):
         )
 
 
-class ReviewDateConfirmation(AdminRequiredMixin, generic.UpdateView):
+class ReviewDateConfirmation(ReviewManagerRequiredMixin, generic.UpdateView):
     model = Review
     lookup_field = "slug"
     form_class = ReviewDateConfirmationForm

--- a/nsc/stakeholder/views.py
+++ b/nsc/stakeholder/views.py
@@ -8,7 +8,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.views import generic
 from django.views.generic import FormView
 
-from nsc.permissions import AdminRequiredMixin
+from nsc.permissions import ReviewManagerRequiredMixin
 from nsc.utils.datetime import get_today
 
 from ..subscription.filters import SearchFilter as SubSearchFilter
@@ -30,7 +30,7 @@ class StakeholderFilterMixin:
         return SearchFilter(self.request.GET, queryset=self.queryset).qs
 
 
-class StakeholderList(AdminRequiredMixin, StakeholderFilterMixin, generic.ListView):
+class StakeholderList(ReviewManagerRequiredMixin, StakeholderFilterMixin, generic.ListView):
     paginate_by = 20
 
     def get_context_data(self, **kwargs):
@@ -45,7 +45,7 @@ class StakeholderList(AdminRequiredMixin, StakeholderFilterMixin, generic.ListVi
         return super().get(*args, **kwargs)
 
 
-class StakeholderExport(AdminRequiredMixin, StakeholderFilterMixin, FormView):
+class StakeholderExport(ReviewManagerRequiredMixin, StakeholderFilterMixin, FormView):
     form_class = ExportForm
     template_name = "stakeholder/stakeholder_export.html"
 
@@ -175,7 +175,7 @@ class StakeholderExport(AdminRequiredMixin, StakeholderFilterMixin, FormView):
         return response
 
 
-class StakeholderDetail(AdminRequiredMixin, generic.DetailView):
+class StakeholderDetail(ReviewManagerRequiredMixin, generic.DetailView):
     model = Stakeholder
 
     def get_context_data(self, **kwargs):
@@ -183,7 +183,7 @@ class StakeholderDetail(AdminRequiredMixin, generic.DetailView):
         return super().get_context_data(**kwargs)
 
 
-class StakeholderAdd(AdminRequiredMixin, generic.CreateView):
+class StakeholderAdd(ReviewManagerRequiredMixin, generic.CreateView):
     model = Stakeholder
     form_class = StakeholderForm
 
@@ -208,7 +208,7 @@ class StakeholderAdd(AdminRequiredMixin, generic.CreateView):
         )
 
 
-class StakeholderEdit(AdminRequiredMixin, generic.UpdateView):
+class StakeholderEdit(ReviewManagerRequiredMixin, generic.UpdateView):
     model = Stakeholder
     form_class = StakeholderForm
 
@@ -227,6 +227,6 @@ class StakeholderEdit(AdminRequiredMixin, generic.UpdateView):
         return context
 
 
-class StakeholderDelete(AdminRequiredMixin, generic.DeleteView):
+class StakeholderDelete(ReviewManagerRequiredMixin, generic.DeleteView):
     model = Stakeholder
     success_url = reverse_lazy("stakeholder:list")

--- a/nsc/stakeholder/views.py
+++ b/nsc/stakeholder/views.py
@@ -30,7 +30,9 @@ class StakeholderFilterMixin:
         return SearchFilter(self.request.GET, queryset=self.queryset).qs
 
 
-class StakeholderList(ReviewManagerRequiredMixin, StakeholderFilterMixin, generic.ListView):
+class StakeholderList(
+    ReviewManagerRequiredMixin, StakeholderFilterMixin, generic.ListView
+):
     paginate_by = 20
 
     def get_context_data(self, **kwargs):

--- a/nsc/urls.py
+++ b/nsc/urls.py
@@ -31,6 +31,7 @@ urlpatterns = [
     path("helpdesk/", include("nsc.support.urls", namespace="support")),
     path(r"_health/", lambda request: HttpResponse()),
     path("_notify/", include("nsc.notify.urls", namespace="notify")),
+    path(r"django-admin/", admin.site.urls),
     path(r"", include("nsc.condition.urls", namespace="condition")),
 ]
 


### PR DESCRIPTION
Added django-admin back into list of URLs, updated permissions mixin so that the rest of the internal site will work for the evidence review manager role, but django-admin is only available to administrators.