### PR TITLE
typos and punctuation corrected

### DIFF
--- a/templates/subscription/stakeholder_subscription_complete.html
+++ b/templates/subscription/stakeholder_subscription_complete.html
@@ -14,7 +14,7 @@
 {% block content %}
   <p class="govuk-body">
     {% blocktrans %}
-      Your request to receive UK National Screening Committee (UK NSC) updated has been submitted.
+      Your request to receive UK National Screening Committee (UK NSC) updates has been submitted.
     {% endblocktrans %}
   </p>
   <p class="govuk-body">

--- a/templates/subscription/stakeholder_subscription_creation.html
+++ b/templates/subscription/stakeholder_subscription_creation.html
@@ -14,14 +14,14 @@
 {% block content %}
   <p class="govuk-body">
     {% blocktrans %}
-      Thank you for subscribing to receive updated on UK National Screening Committee (UK NSC)
-      consultations. Please provide your email address below
+      Thank you for subscribing to receive updates on UK National Screening Committee (UK NSC)
+      consultations. Please provide your email address below.
     {% endblocktrans %}
   </p>
 
   <p class="govuk-body">
     {% blocktrans %}
-      A member of the UK Secretariat will contact you within 3 working days.
+      A member of the UK NSC Secretariat will contact you within 3 working days.
     {% endblocktrans %}
   </p>
 
@@ -54,7 +54,7 @@
 
     <p class="govuk-body">
       {% blocktrans with privacy_policy_url="https://www.gov.uk/government/organisations/uk-national-screening-committee/about/personal-information-charter" %}
-        We wont share your email address with anyone. Read our
+        We will not share your email address with anyone. Read our
         <a class="govuk-link" href="{{ privacy_policy_url }}" target="_blank">privacy notice</a>.
       {% endblocktrans %}
     </p>


### PR DESCRIPTION
Corrected typos and punctuation on https://view-health-screening-recommendations.service.gov.uk/subscribe/stakeholder-start/. At the moment this page is orphaned as the navigation is not correct but fixing now since it has been noticed.